### PR TITLE
Fix processing when having multiple values in dbsnp_RS field in VCFs

### DIFF
--- a/gcn/lib/io/vcf.py
+++ b/gcn/lib/io/vcf.py
@@ -22,7 +22,10 @@ from gcn.lib.io import anyopen
 # dictionary VCF data type to python functions
 def toint(v):
     """Check and convert a value to an integer"""
-    return int(v) if not v in '.AG' else v
+    if v.isdigit():
+        return int(v) if not v in '.AG' else v
+    else:
+        return v
 
 
 def tofloat(v):


### PR DESCRIPTION
This prevents error field not being convertible to an int when dbSNP rs values are like "201747181,77270114". This happen in cases where multiple values exist for a given variant.